### PR TITLE
json: add range check for deserialized numeric value

### DIFF
--- a/src/json/format.hpp
+++ b/src/json/format.hpp
@@ -22,6 +22,9 @@ template <class T>
     requires(std::integral<T> || std::floating_point<T>)
 auto deserialize_element(const ::json::Value& value, T& data) -> bool {
     unwrap(node, value.get<::json::Number>());
+    constexpr auto min = std::numeric_limits<T>::lowest();
+    constexpr auto max = std::numeric_limits<T>::max();
+    ensure(min <= node.value && node.value <= max, "{0} is out of range, must be {1} <= {0} <= {2}", node.value, min, max);
     data = node.value;
     return true;
 }

--- a/tests/json.cpp
+++ b/tests/json.cpp
@@ -206,6 +206,24 @@ auto packed() -> int {
     return 0;
 }
 
+// out of range
+struct OutOfRange {
+    SerdeFieldsBegin;
+    float SerdeField(a);
+    SerdeFieldsEnd;
+};
+
+auto out_of_range() -> int {
+    // max float value is 3.402823466e+38, 3.502823466e+38 is out of range
+    const auto str = R"({
+        "a": 3.502823466e+38
+    })";
+
+    unwrap(node_pre, json::parse(str));
+    ensure(!(serde::load<serde::JsonFormat, OutOfRange>(node_pre)));
+    return 0;
+}
+
 auto main() -> int {
     ensure(primitives() == 0);
     ensure(containers() == 0);
@@ -214,6 +232,7 @@ auto main() -> int {
     ensure(missing_field() == 0);
     ensure(mismatched_array_length() == 0);
     ensure(packed() == 0);
+    ensure(out_of_range() == 0);
     std::println("pass");
     return 0;
 }


### PR DESCRIPTION
since deserialize value is stored as double, it may overflow when assigned to a variable of numeric type.

overflow test
```
$ ninja -C debug
$ ./debug/tests/json
failed to deserialize field "b"(key="b")
failed to deserialize field "a"(key="a")
3.502823466e+38 is out of range, must be -3.4028235e+38 <= 3.502823466e+38 <= 3.4028235e+38
failed to deserialize field "a"(key="a")
pass
```